### PR TITLE
Add unit tests for R queries

### DIFF
--- a/etc/r/install_prereq.r
+++ b/etc/r/install_prereq.r
@@ -1,0 +1,3 @@
+temp_libPaths <- .libPaths()
+.libPaths(temp_libPaths[2])
+install.packages("testthat", repos='http://cran.us.r-project.org', quiet = TRUE)

--- a/kernel-r/declarativewidgets/DESCRIPTION
+++ b/kernel-r/declarativewidgets/DESCRIPTION
@@ -9,11 +9,18 @@ Authors@R: c(person("Michael", "Poplavski", role = c("aut", "cre"),
 Maintainer: Jupyter Development Team <jupyter@googlegroups.com>
 Depends:
     R (>= 3.0.1)
+Suggests:
+    testthat (>= 0.7)
 License: MIT + file LICENSE
 LazyData: true
 Encoding: UTF-8
 Imports:
-    IRkernel
+    IRkernel,
+    IRdisplay,
+    uuid,
+    jsonlite,
+    R6,
+    SparkR
 Collate:
     'widget.r'
     'widget_function.r'

--- a/kernel-r/declarativewidgets/R/querier.r
+++ b/kernel-r/declarativewidgets/R/querier.r
@@ -18,7 +18,6 @@ Querier <- R6Class(
                 return (df)
             } else {
                 new_df <- df
-                query_type_expr_map <- list()
                 for(i in 1:length(query$type)) {
                     expr <- if (length(query$type) > 1) query$expr[[i]] else query$expr
                     if(query$type[[i]] == "group") {

--- a/kernel-r/declarativewidgets/R/queriers.r
+++ b/kernel-r/declarativewidgets/R/queriers.r
@@ -39,10 +39,10 @@ Spark_DataFrame_Querier <- R6Class(
         inherit = Querier,
         public = list(
         handle_sort = function(df, sort_expr) {
-            return (arrange(sparkFares, sort_expr$by, decreasing=(sort_expr$ascending == "FALSE")))
+            return (arrange(df, sort_expr$by, decreasing=(sort_expr$ascending == "FALSE")))
         },
         handle_filter = function(df, filter_expr) {
-            return (filter(sparkFares, filter_expr))
+            return (filter(df, filter_expr))
         },
         handle_group = function(df, grp_expr) {
             agg_args <- list()
@@ -55,7 +55,7 @@ Spark_DataFrame_Querier <- R6Class(
                 temp_name <- paste(grp_expr$agg[2][,1][i], "_", grp_expr$agg[1][,1][i], sep="")
                 col_names <- append(col_names, temp_name)
             }
-            new_df <- collect(do.call(agg, agg_args))
+            new_df <- do.call(agg, agg_args)
             col_names <- append(names(new_df)[1], col_names)
             names(new_df) <- col_names
             return (new_df)

--- a/kernel-r/declarativewidgets/man/widgets-package.Rd
+++ b/kernel-r/declarativewidgets/man/widgets-package.Rd
@@ -31,6 +31,3 @@ Maintainer: \packageMaintainer{declarativewidgets}
 ~~ Optional links to other man pages, e.g. ~~
 ~~ \code{\link[<pkg>:<pkg>-package]{<pkg>}} ~~
 }
-\examples{
-~~ simple examples of the most important functions ~~
-}

--- a/kernel-r/declarativewidgets/tests/testthat.R
+++ b/kernel-r/declarativewidgets/tests/testthat.R
@@ -1,0 +1,6 @@
+#Note file extensions must by capital .R for R CMD check to pick up the tests
+
+library(testthat)
+library(declarativewidgets)
+
+test_check("declarativewidgets")

--- a/kernel-r/declarativewidgets/tests/testthat/test_df_queries.R
+++ b/kernel-r/declarativewidgets/tests/testthat/test_df_queries.R
@@ -1,0 +1,96 @@
+context("test_df_queries")
+
+#common querier
+querier <- Querier$new()
+#common df
+letters <- c('A', 'B', 'C', 'C', 'C', 'D')
+numbers <- c(1, 2, 3, 4, 5, 6)
+df <- data.frame(letters, numbers)
+df$letters <- as.character(df$letters)
+#common spark_df
+library(SparkR)
+sc <- sparkR.init()
+sqlContext <- sparkRSQL.init(sc)
+spark_df <- createDataFrame(sqlContext, df)
+
+test_that("apply_query_single_filter", {
+    #note the filter equality difference on those query strings
+    single_filter_query_df <- "[{\"type\":\"filter\",\"expr\":\"letters == 'C'\"}]"
+    new_df <- querier$apply_query(df, fromJSON(single_filter_query_df))
+    expect_equal(nrow(new_df), 3)
+
+    single_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}]"
+    new_spark_df <- querier$apply_query(spark_df, fromJSON(single_filter_query_spark_df))
+    expect_equal(nrow(collect(new_spark_df)), 3)
+})
+
+test_that("apply_query_multiple_filters", {
+    multiple_filter_query_df <- "[{\"type\":\"filter\",\"expr\":\"letters == 'C'\"}, {\"type\":\"filter\",\"expr\":\"numbers == '4'\"}]"
+    new_df <- querier$apply_query(df, fromJSON(multiple_filter_query_df))
+    expect_equal(nrow(new_df), 1)
+
+    multiple_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"filter\",\"expr\":\"numbers = '4'\"}]"
+    new_spark_df <- querier$apply_query(spark_df, fromJSON(multiple_filter_query_spark_df))
+    expect_equal(nrow(collect(new_spark_df)), 1)
+})
+
+test_that("apply_query_sort_ascending_false", {
+    sort_query <- "[{\"type\":\"sort\",\"expr\":{\"by\":\"numbers\",\"ascending\":false}}]"
+    query <- fromJSON(sort_query)
+
+    new_df <- querier$apply_query(df, query)
+    expect_equal(as.numeric(new_df$numbers[1]), 6)
+
+    new_spark_df <- querier$apply_query(spark_df, query)
+    expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 6)
+})
+
+test_that("apply_query_sort_ascending_true", {
+    sort_query <- "[{\"type\":\"sort\",\"expr\":{\"by\":\"numbers\",\"ascending\":true}}]"
+    query <- fromJSON(sort_query)
+
+    new_df <- querier$apply_query(df, query)
+    expect_equal(as.numeric(new_df$numbers[1]), 1)
+
+    new_spark_df <- querier$apply_query(spark_df, query)
+    expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 1)
+})
+
+test_that("apply_query_sort_and_filter", {
+    sort_and_filter_query_df <- "[{\"type\":\"filter\",\"expr\":\"letters == 'C'\"}, {\"type\":\"sort\",\"expr\":{\"by\":\"numbers\",\"ascending\":false}}]"
+    new_df <- querier$apply_query(df, fromJSON(sort_and_filter_query_df))
+    expect_equal(as.numeric(new_df$numbers[1]), 5)
+
+    sort_and_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"sort\",\"expr\":{\"by\":\"numbers\",\"ascending\":false}}]"
+    new_spark_df <- querier$apply_query(spark_df, fromJSON(sort_and_filter_query_spark_df))
+    expect_equal(as.numeric(collect(new_spark_df)$numbers[1]), 5)
+})
+
+test_that("apply_query_groupby", {
+    groupby_query <- "[{\"type\":\"group\",\"expr\":{\"by\":[\"letters\"],\"agg\":[{\"op\":\"sum\",\"col\":\"numbers\"},{\"op\":\"mean\",\"col\":\"numbers\"}]}}]"
+    query <- fromJSON(groupby_query)
+
+    new_df <- querier$apply_query(df, query)
+    expect_equal(nrow(new_df), 4)
+    expect_equal(as.numeric(new_df$numbers_sum[3]), 12)
+    expect_equal(as.numeric(new_df$numbers_mean[3]), 4)
+
+    new_spark_df <- querier$apply_query(spark_df, query)
+    expect_equal(nrow(collect(new_spark_df)), 4)
+    expect_equal(as.numeric(collect(new_spark_df)$numbers_sum[3]), 12)
+    expect_equal(as.numeric(collect(new_spark_df)$numbers_mean[3]), 4)
+})
+
+test_that("apply_query_groupby_and_filter", {
+    groupby_and_filter_query_df <- "[{\"type\":\"filter\",\"expr\":\"letters == 'C'\"}, {\"type\":\"group\",\"expr\":{\"by\":[\"letters\"],\"agg\":[{\"op\":\"sum\",\"col\":\"numbers\"},{\"op\":\"mean\",\"col\":\"numbers\"}]}}]"
+    new_df <- querier$apply_query(df, fromJSON(groupby_and_filter_query_df))
+    expect_equal(nrow(new_df), 1)
+    expect_equal(as.numeric(new_df$numbers_sum[1]), 12)
+    expect_equal(as.numeric(new_df$numbers_mean[1]), 4)
+
+    groupby_and_filter_query_spark_df <- "[{\"type\":\"filter\",\"expr\":\"letters = 'C'\"}, {\"type\":\"group\",\"expr\":{\"by\":[\"letters\"],\"agg\":[{\"op\":\"sum\",\"col\":\"numbers\"},{\"op\":\"mean\",\"col\":\"numbers\"}]}}]"
+    new_spark_df <- querier$apply_query(spark_df, fromJSON(groupby_and_filter_query_spark_df))
+    expect_equal(nrow(collect(new_spark_df)), 1)
+    expect_equal(as.numeric(collect(new_spark_df)$numbers_sum[1]), 12)
+    expect_equal(as.numeric(collect(new_spark_df)$numbers_mean[1]), 4)
+})


### PR DESCRIPTION
- Adds target `test-r` and added it to `test` target.
- Tests dataframe and spark dataframes at the apply query level taking in the df and json.
- Fixed a few issues discovered when testing (variable naming and collecting where shouldn't have).
  - The spark issue I was having early was misleading it was actually that the filter string I was using was for regular df as in == and not =.
- FYI, The log output adds ~60 lines and takes ~40 or 50 seconds to run.
